### PR TITLE
Fix For `fix_untrained_tokens` With Qwen3 LoRA

### DIFF
--- a/src/axolotl/contribs/lgpl/unsloth.py
+++ b/src/axolotl/contribs/lgpl/unsloth.py
@@ -63,8 +63,18 @@ def get_embedding_mean(input_embeddings, output_embeddings, tokenizer, train_dat
     # Sometimes the sizes can be different like in vision models
     # Ie <image> is in input, but not in output
     min_size = min(input_embeddings.weight.shape[1], output_embeddings.weight.shape[1])
-    input_embeddings.weight = torch.nn.Parameter(input_embeddings.weight[:, :min_size])
-    output_embeddings.weight = torch.nn.Parameter(output_embeddings.weight[:, :min_size])
+    with torch.no_grad():
+        # Slice off the extra dims in‐place
+        input_embeddings.weight.data = input_embeddings.weight.data[:, :min_size]
+        output_embeddings.weight.data = output_embeddings.weight.data[:, :min_size]
+
+    # Update the dim sizes
+    input_embeddings.embedding_dim = min_size
+    output_embeddings.embedding_dim = min_size
+
+    # Ensure dims are trainable
+    input_embeddings.weight.requires_grad_(True)
+    output_embeddings.weight.requires_grad_(True)
 
     # Get untrained tokens
     indicator_untrained1 = torch.amax(input_embeddings.weight, axis=1) <= eps


### PR DESCRIPTION
*Hopefully* fixes axolotl-ai-cloud/axolotl#2660 without introducing problems elsewhere.

# Testing

I lowered the `sequence_len` to 1024 and `micro_batch_size` to 1 since it uses *a lot* of memory (~24gb with the below config 😔).

<details>
  <summary>Axolotl Config</summary>

```yaml
# Model checkpointing config
output_dir: ./Outputs/Qwen3-Samantha-4B-LoRA
save_steps: 100
save_safetensors: true
save_total_limit: 2
save_only_model: true

# Model architecture config
base_model: Qwen/Qwen3-4B-Base
model_type: AutoModelForCausalLM
tokenizer_type: AutoTokenizer

# Mixed precision training config
bf16: true
fp16: false
tf32: false

# Model loading config
load_in_8bit: false
load_in_4bit: false
strict: false

# Sequence config
sequence_len: 1024
min_sample_len:
sample_packing: false
eval_sample_packing: false
pad_to_sequence_len: true
train_on_inputs: false
group_by_length: false

# LoRA adapter config
adapter: lora
lora_r: 16
lora_alpha: 16
lora_dropout: 0.125
lora_target_modules:
  - gate_proj
  - down_proj
  - up_proj
  - q_proj
  - v_proj
  - k_proj
  - o_proj
lora_modules_to_save:
  - embed_tokens

# Fix uninitialized tokens (such as <|start_header_id|> on the base L3 models)
fix_untrained_tokens: [151644, 151645]

# Dataset config
chat_template_jinja: "{% for message in messages %}{{ '<|im_start|>' + message['role'] + '\n' + message['content'] | trim + '<|im_end|>' }}{% if not loop.last %}{{ '\n' }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '\n<|im_start|>assistant\n' }}{% endif %}"
datasets:
  - path: digitalpipelines/samantha-1.1-uncensored
    type: chat_template
    field_messages: conversations
    message_property_mappings:
      role: from
      content: value
  - path: lodrick-the-lafted/Samantha-Opus
    type: chat_template
    field_messages: conversations
    message_property_mappings:
      role: from
      content: value
test_datasets:
val_set_size: 0.05
eval_strategy: steps
eval_steps: 10
dataset_prepared_path: ./00-Tokenized-Datasets/Qwen3-Samantha-4B-seed42
shuffle_merged_datasets: true

# Training hyperparameters
num_epochs: 1
gradient_accumulation_steps: 16
micro_batch_size: 1
eval_batch_size: 1
warmup_steps: 0
optimizer: came_pytorch
optim_args:
optim_target_modules:
lr_scheduler: rex
learning_rate: 1e-5
cosine_min_lr_ratio: 0.05
loraplus_lr_ratio:
loraplus_lr_embedding:
weight_decay: 0.1
max_grad_norm: 0.5
logging_steps: 1

# Model optimization
gradient_checkpointing: offload
sdp_attention: true
plugins:
  - axolotl.integrations.liger.LigerPlugin
  - axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
cut_cross_entropy: true
liger_rope: true
liger_rms_norm: true
liger_layer_norm: true
liger_glu_activation: true
liger_cross_entropy: false
liger_fused_linear_cross_entropy: false
lora_mlp_kernel: false
lora_qkv_kernel: false
lora_o_kernel: false

# DeepSpeed
deepspeed:

# Garbage Collection
gc_steps:

# Debug config
debug: true
seed: 42

# Token config
special_tokens:
  eos_token: "<|im_end|>"
  pad_token: "<|endoftext|>"
tokens:
```

</details>

<details>
  <summary>Axolotl Training Log</summary>

```sh
> accelerate launch -m axolotl.cli.train problem_qwen3.yaml

WARNING:accelerate.commands.launch:The following values were not passed to `accelerate launch` and had defaults used instead:
        `--num_processes` was set to a value of `1`
        `--num_machines` was set to a value of `1`
        `--mixed_precision` was set to a value of `'no'`
        `--dynamo_backend` was set to a value of `'no'`
To avoid this warning pass in values for each of the problematic parameters or run `accelerate config`.
[2025-05-10 17:39:16,023] [INFO] [real_accelerator.py:219:get_accelerator] Setting ds_accelerator to cuda (auto detect)
[2025-05-10 17:39:16,140] [INFO] [root.spawn:77] [PID:113283] x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -c /media/xzuyn/NVMe/LClones/tmp/tmp4jdymwrq/test.c -o /media/xzuyn/NVMe/LClones/tmp/tmp4jdymwrq/test.o
[2025-05-10 17:39:16,153] [INFO] [root.spawn:77] [PID:113283] x86_64-linux-gnu-gcc /media/xzuyn/NVMe/LClones/tmp/tmp4jdymwrq/test.o -laio -o /media/xzuyn/NVMe/LClones/tmp/tmp4jdymwrq/a.out
[2025-05-10 17:39:17,201] [INFO] [datasets.<module>:54] [PID:113283] PyTorch version 2.8.0.dev20250502+rocm6.3 available.
INFO 05-10 17:39:21 __init__.py:183] Automatically detected platform rocm.
WARNING 05-10 17:39:21 rocm.py:31] `fork` method is not supported by ROCm. VLLM_WORKER_MULTIPROC_METHOD is overridden to `spawn` instead.
[2025-05-10 17:39:22,411] [INFO] [root.register:348] [PID:113283] Attempting to load plugin: axolotl.integrations.liger.LigerPlugin
[2025-05-10 17:39:22,414] [INFO] [root.register:351] [PID:113283] Plugin loaded successfully: axolotl.integrations.liger.LigerPlugin
[2025-05-10 17:39:22,414] [INFO] [root.register:348] [PID:113283] Attempting to load plugin: axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
[2025-05-10 17:39:22,416] [INFO] [root.register:351] [PID:113283] Plugin loaded successfully: axolotl.integrations.cut_cross_entropy.CutCrossEntropyPlugin
[2025-05-10 17:39:22,679] [WARNING] [axolotl.utils.schemas.config.hint_lora_8bit:846] [PID:113283] [RANK:0] We recommend setting `load_in_8bit: true` for LORA finetuning
[2025-05-10 17:39:23,103] [INFO] [axolotl.normalize_config:237] [PID:113283] [RANK:0] cuda memory usage baseline: 0.000GB ()

     #@@ #@@      @@# @@#
    @@  @@          @@  @@           =@@#                               @@                 #@    =@@#.
    @@    #@@@@@@@@@    @@           #@#@=                              @@                 #@     .=@@
      #@@@@@@@@@@@@@@@@@            =@# @#     ##=     ##    =####=+    @@      =#####+  =#@@###.   @@
    @@@@@@@@@@/  +@@/  +@@          #@  =@=     #@=   @@   =@#+  +#@#   @@    =@#+  +#@#   #@.      @@
    @@@@@@@@@@  ##@@  ##@@         =@#   @#      =@# @#    @@      @@   @@    @@      #@   #@       @@
     @@@@@@@@@@@@@@@@@@@@          #@=+++#@=      =@@#     @@      @@   @@    @@      #@   #@       @@
                                  =@#=====@@     =@# @#    @@      @@   @@    @@      #@   #@       @@
    @@@@@@@@@@@@@@@@  @@@@        #@      #@=   #@=  +@@   #@#    =@#   @@.   =@#    =@#   #@.      @@
                                 =@#       @#  #@=     #@   =#@@@@#=    +#@@=  +#@@@@#=    .##@@+   @@
    @@@@  @@@@@@@@@@@@@@@@

[2025-05-10 17:39:23,503] [DEBUG] [axolotl.utils.models.load_tokenizer:457] [PID:113283] [RANK:0] EOS: 151645 / <|im_end|>
[2025-05-10 17:39:23,503] [DEBUG] [axolotl.utils.models.load_tokenizer:458] [PID:113283] [RANK:0] BOS: None / None
[2025-05-10 17:39:23,503] [DEBUG] [axolotl.utils.models.load_tokenizer:459] [PID:113283] [RANK:0] PAD: 151643 / <|endoftext|>
[2025-05-10 17:39:23,503] [DEBUG] [axolotl.utils.models.load_tokenizer:460] [PID:113283] [RANK:0] UNK: None / None
[2025-05-10 17:39:23,504] [INFO] [axolotl.utils.data.sft.load_tokenized_prepared_datasets:260] [PID:113283] [RANK:0] Loading prepared dataset from disk at 00-Tokenized-Datasets/Qwen3-Samantha-4B-seed42/7e9b40b5e46c83e8038ed2d403c655ac...
[2025-05-10 17:39:23,507] [INFO] [axolotl.utils.data.sft.load_tokenized_prepared_datasets:262] [PID:113283] [RANK:0] Prepared dataset loaded from disk...
[2025-05-10 17:39:23,516] [DEBUG] [axolotl.calculate_total_num_steps:405] [PID:113283] [RANK:0] total_num_tokens: 1_686_876
[2025-05-10 17:39:23,549] [DEBUG] [axolotl.calculate_total_num_steps:423] [PID:113283] [RANK:0] `total_supervised_tokens: 1_196_626`
[2025-05-10 17:39:23,549] [DEBUG] [axolotl.calculate_total_num_steps:516] [PID:113283] [RANK:0] total_num_steps: 231
[2025-05-10 17:39:23,582] [DEBUG] [axolotl.train.setup_model_and_tokenizer:64] [PID:113283] [RANK:0] loading tokenizer... Qwen/Qwen3-4B-Base
[2025-05-10 17:39:23,906] [DEBUG] [axolotl.utils.models.load_tokenizer:457] [PID:113283] [RANK:0] EOS: 151645 / <|im_end|>
[2025-05-10 17:39:23,906] [DEBUG] [axolotl.utils.models.load_tokenizer:458] [PID:113283] [RANK:0] BOS: None / None
[2025-05-10 17:39:23,906] [DEBUG] [axolotl.utils.models.load_tokenizer:459] [PID:113283] [RANK:0] PAD: 151643 / <|endoftext|>
[2025-05-10 17:39:23,906] [DEBUG] [axolotl.utils.models.load_tokenizer:460] [PID:113283] [RANK:0] UNK: None / None
[2025-05-10 17:39:23,906] [DEBUG] [axolotl.train.setup_model_and_tokenizer:78] [PID:113283] [RANK:0] loading model and peft_config...
[2025-05-10 17:39:24,077] [INFO] [axolotl.integrations.liger.pre_model_load:89] [PID:113283] [RANK:0] Applying LIGER to qwen3 with kwargs: {'rope': True, 'cross_entropy': False, 'fused_linear_cross_entropy': False, 'rms_norm': True, 'swiglu': True}
[2025-05-10 17:39:24,172] [INFO] [axolotl.integrations.cut_cross_entropy.pre_model_load:80] [PID:113283] [RANK:0] Applying Cut Cross Entropy to model type: qwen3
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 45.16it/s]
[2025-05-10 17:39:24,927] [INFO] [axolotl.utils.models.load_model:1357] [PID:113283] [RANK:0] Converting modules to torch.bfloat16
trainable params: 421,986,304 || all params: 4,444,454,400 || trainable%: 9.4947
[2025-05-10 17:39:26,150] [INFO] [axolotl.utils.models.load_model:1418] [PID:113283] [RANK:0] cuda memory usage after adapters: 0.000GB ()
/media/xzuyn/NVMe/LClones/axolotl/src/axolotl/core/trainers/base.py:64: FutureWarning: `tokenizer` is deprecated and will be removed in version 5.0.0 for `AxolotlTrainer.__init__`. Use `processing_class` instead.
  super().__init__(*_args, **kwargs)
No label_names provided for model class `PeftModelForCausalLM`. Since `PeftModel` hides base models input arguments, if label_names is not given, label_names can't be set automatically within `Trainer`. Note that empty label_names list will be used instead.
Counting untrained tokens: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3685/3685 [00:00<00:00, 5509.74 examples/s]
[2025-05-10 17:39:31,550] [INFO] [axolotl.contribs.lgpl.unsloth.get_embedding_mean:253] [PID:113283] [RANK:0] Rescaling embeddings for tokens seen in train_dataset: [151644, 151645]
[2025-05-10 17:39:37,481] [INFO] [axolotl.train.save_initial_configs:374] [PID:113283] [RANK:0] Pre-saving adapter config to ./Outputs/Qwen3-Samantha-4B-LoRA...
[2025-05-10 17:39:37,481] [INFO] [axolotl.train.save_initial_configs:378] [PID:113283] [RANK:0] Pre-saving tokenizer to ./Outputs/Qwen3-Samantha-4B-LoRA...
[2025-05-10 17:39:37,681] [INFO] [axolotl.train.save_initial_configs:381] [PID:113283] [RANK:0] Pre-saving model config to ./Outputs/Qwen3-Samantha-4B-LoRA...
[2025-05-10 17:39:37,684] [INFO] [axolotl.train.execute_training:211] [PID:113283] [RANK:0] Starting trainer...
  0%|                                                                                                                                                                                                       | 0/230 [00:00<?, ?it/s]You're using a Qwen2TokenizerFast tokenizer. Please note that with a fast tokenizer, using the `__call__` method is faster than using a method to encode the text followed by a call to the `pad` method to get a padded encoding.
{'loss': 1.4723, 'grad_norm': 5.6237287521362305, 'learning_rate': 9.995853339153208e-06, 'epoch': 0.0}                                                                                                                             
{'eval_loss': 1.600857138633728, 'eval_runtime': 46.6054, 'eval_samples_per_second': 4.163, 'eval_steps_per_second': 4.163, 'epoch': 0.0}                                                                                           
  0%|▊                                                                                                                                                                                            | 1/230 [01:07<1:15:26, 19.77s/it]
[2025-05-10 17:41:00,748] [INFO] [axolotl.callbacks.on_step_end:128] [PID:113283] [RANK:0] cuda memory usage while training: 11.554GB (+11.659GB cache)                                                                             
{'loss': 1.5334, 'grad_norm': 7.203862190246582, 'learning_rate': 9.991673970201578e-06, 'epoch': 0.01}                                                                                                                             
{'loss': 1.724, 'grad_norm': 4.159517288208008, 'learning_rate': 9.987461504619447e-06, 'epoch': 0.01}                                                                                                                              
{'loss': 1.497, 'grad_norm': 3.7544727325439453, 'learning_rate': 9.983215547703181e-06, 'epoch': 0.02}                                                                                                                             
{'loss': 1.3783, 'grad_norm': 3.5708982944488525, 'learning_rate': 9.978935698447894e-06, 'epoch': 0.02}                                                                                                                            
{'loss': 1.7276, 'grad_norm': 3.67960786819458, 'learning_rate': 9.974621549421194e-06, 'epoch': 0.03}                                                                                                                              
{'loss': 1.6827, 'grad_norm': 3.1187901496887207, 'learning_rate': 9.970272686633886e-06, 'epoch': 0.03}                                                                                                                            
{'loss': 1.4878, 'grad_norm': 2.8121652603149414, 'learning_rate': 9.96588868940754e-06, 'epoch': 0.03}                                                                                                                             
{'loss': 1.4926, 'grad_norm': 2.4641945362091064, 'learning_rate': 9.961469130238847e-06, 'epoch': 0.04}                                                                                                                            
{'loss': 1.5056, 'grad_norm': 2.4847686290740967, 'learning_rate': 9.957013574660635e-06, 'epoch': 0.04}                                                                                                                            
{'eval_loss': 1.5882118940353394, 'eval_runtime': 43.3454, 'eval_samples_per_second': 4.476, 'eval_steps_per_second': 4.476, 'epoch': 0.04}                                                                                         
{'loss': 1.546, 'grad_norm': 2.8105170726776123, 'learning_rate': 9.952521581099502e-06, 'epoch': 0.05}                                                                                                                             
```

</details>